### PR TITLE
get rid of sharkdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-.DS_Store
-Thumbs.db
-
-.nvm-version
-node_modules
-npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+Thumbs.db
+
+.nvm-version
+node_modules
+npm-debug.log

--- a/HELP.md
+++ b/HELP.md
@@ -1,5 +1,0 @@
-geojson-flatten
-
-usage:
-
-    geojson-flatten < file.geojson > output.geojson

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Or download `geojson-flatten.js` for non-[browserify](http://browserify.org/) us
 
 ## example
 
-```
+```js
 var flatten = require('geojson-flatten');
 
 flattened = flatten(geojsonObject);
 ```
+
+## cli
+
+	cat input.geojson | geojson-flatten > flattened.geojson

--- a/geojson-flatten
+++ b/geojson-flatten
@@ -2,12 +2,14 @@
 
 var flatten = require('./'),
     concat = require('concat-stream'),
-    sharkdown = require('sharkdown'),
     fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2));
 
 if (process.stdin.isTTY && !argv._[0]) {
-    process.stdout.write(sharkdown(fs.readFileSync(__dirname + '/HELP.md')));
+    process.stdout.write(`
+Usage:
+	cat input.geojson | geojson-flatten > flattened.geojson
+\n`);
     process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "transform geojson into single-parts",
   "main": "index.js",
   "files": [
-  	"index.js",
-  	"geojson-flatten"
+    "index.js",
+    "geojson-flatten"
   ],
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "description": "transform geojson into single-parts",
   "main": "index.js",
+  "files": [
+  	"index.js",
+  	"geojson-flatten"
+  ],
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "homepage": "https://github.com/mapbox/geojson-flatten",
   "dependencies": {
     "concat-stream": "~1.2.1",
-    "minimist": "0.0.5",
-    "sharkdown": "~0.1.0"
+    "minimist": "0.0.5"
   },
   "devDependencies": {
     "tap": "^2.3.1",


### PR DESCRIPTION
This PR fixes #5 by making `geojson-flatten` printing the CLI help in plain text.